### PR TITLE
securing github actions

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,12 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: '1.23'
       - name: Generate Client
-        uses: grafana/shared-workflows/actions/generate-openapi-clients@main
+        uses: grafana/shared-workflows/actions/generate-openapi-clients@fa48192dac470ae356b3f7007229f3ac28c48a25
         with:
           package-name: slo
           spec-path: openapi.yaml
-


### PR DESCRIPTION
Securing GH actions as followup from [the incident on April 26th 2025](https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/).

--
Signed-off-by: JuanJo Ciarlante <juanjosec@gmail.com>
