### PR TITLE
Harden generate workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,13 +13,12 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
     env:
       REPO_NAME: slo-openapi-client
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: true
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.26.1'
@@ -32,6 +31,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
+          sign-commits: true
           commit-message: "Update generated OpenAPI clients"
           title: "Update OpenAPI clients"
           body: "Auto-generated client update after OpenAPI spec change."


### PR DESCRIPTION
## Summary

Three least-privilege tightenings to `.github/workflows/generate.yml`:

1. **`persist-credentials: false`** on `actions/checkout`. The persisted `GITHUB_TOKEN` is unused since the workflow switched to `peter-evans/create-pull-request` in #16, which authenticates via its own `token` input (default: `${{ github.token }}`). Verified against the action README at the pinned SHA (`22a9089...`). Removing the persisted credential reduces blast radius if any later step is compromised.

2. **Drop `id-token: write`** from job permissions. Verified the shared `grafana/shared-workflows/actions/generate-openapi-clients` action at the pinned SHA (`8ef55db...`) does not consume OIDC: no Vault calls, no `ACTIONS_ID_TOKEN_*` reads, and the optional commit step (gated by `commit-changes: true`, which we set to `false`) uses standard git credentials. The permission is dead weight today.

3. **`sign-commits: true`** on `peter-evans/create-pull-request`. The action commits via the GitHub API and the resulting commit carries the green Verified badge. Future-proofs the workflow against a "require signed commits" branch protection rule and makes auto-generated commits distinguishable from arbitrary pushes to the same branch name.

## Test plan

- [ ] Workflow triggers only on `push` to `main`, so this PR itself will not run the workflow. Verification has to wait until a follow-up spec change lands.
- [ ] After merge, on the next `openapi.yaml` change, confirm the workflow run succeeds and the resulting `auto/update-openapi-clients` PR shows a Verified commit by `github-actions[bot]`.