### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @grafana/slo-squad


### PR DESCRIPTION
## Summary

Adds `@grafana/slo-squad` as default code owner for the entire repository.

Defense in depth: ensures slo-squad review is required on every PR, including the auto-generated client updates from `.github/workflows/generate.yml` and any changes to that workflow itself. Without this, a single committer could land a workflow change (e.g., adding a credential-exfil step) with only their own approval if branch protection is configured to allow it.

## Notes

* Effective only if branch protection on `main` has *"Require review from Code Owners"* enabled. If that setting is off, this file is advisory and the PR is still useful as documentation.
* `*` covers the whole tree intentionally. This includes `go/slo/**`, which is the path the auto-update PRs touch. Treating those PRs as needing a human reviewer is the intent (they always have, but now it's encoded).